### PR TITLE
feat(deps): add subdirectory support for dependency vendoring

### DIFF
--- a/.github/workflows/build-dep-tarballs.yml
+++ b/.github/workflows/build-dep-tarballs.yml
@@ -82,7 +82,8 @@ jobs:
             --arg repo "${{ matrix.repo }}" \
             --arg vcs "${{ matrix.vcs }}" \
             --arg tag "${{ matrix.tag }}" \
-            '{name: $name, repo: $repo, vcs: $vcs, tag: $tag}' \
+            --arg subdir "${{ matrix.subdir }}" \
+            '{name: $name, repo: $repo, vcs: $vcs, tag: $tag, subdir: $subdir}' \
             | bash ci/build-"${{ matrix.language }}"-deps.sh)"
           echo "tarball=${tarball}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/manual-build-dep-tarballs.yml
+++ b/.github/workflows/manual-build-dep-tarballs.yml
@@ -66,7 +66,7 @@ jobs:
             exit 1
           fi
 
-          jq -r '"repo=" + .repo, "vcs=" + .vcs' <<< "$config_entry" >> "$GITHUB_OUTPUT"
+          jq -r '"repo=" + .repo, "vcs=" + .vcs, "subdir=" + (.subdir // "")' <<< "$config_entry" >> "$GITHUB_OUTPUT"
 
           release_tag="${package_name}-${tag_version}"
           if [[ "${{ inputs.force_build }}" != "true" ]]; then
@@ -84,7 +84,8 @@ jobs:
             --arg repo "${{ steps.validate.outputs.repo }}" \
             --arg vcs "${{ steps.validate.outputs.vcs }}" \
             --arg tag "${{ inputs.tag_version }}" \
-            '{name: $name, repo: $repo, vcs: $vcs, tag: $tag}' \
+            --arg subdir "${{ steps.validate.outputs.subdir }}" \
+            '{name: $name, repo: $repo, vcs: $vcs, tag: $tag, subdir: $subdir}' \
             | bash ci/build-${{ inputs.language }}-deps.sh)"
           echo "tarball=${tarball}" >> $GITHUB_OUTPUT
 

--- a/README.md
+++ b/README.md
@@ -4,25 +4,29 @@ This repo provides pipelines for automatically vendoring distfiles required for 
 
 ## Configuration
 
-Dependencies to vendor are defined in [vendor_manifest.json](config/vendor_manifest.json).  Each key in the manifest corresponds to a language (e.g. `go`, `rust`) and lists the repositories to vendor.  Example:
+Dependencies to vendor are defined in [vendor_manifest.json](config/vendor_manifest.json).  Each key in the manifest corresponds to a language (e.g. `go`, `rust`) and lists the repositories to vendor.  Entries may optionally specify a `subdir` to vendor from within the repository.  Example:
 
 ```json
 {
   "go": [
-    { "name": "glow", "repo": "charmbracelet/glow", "vcs": "https://github.com/charmbracelet/glow.git" }
+    { "name": "glow", "repo": "charmbracelet/glow", "vcs": "https://github.com/charmbracelet/glow.git", "subdir": "" }
   ],
   "rust": [
-    { "name": "lutgen-rs", "repo": "ozwaldorf/lutgen-rs", "vcs": "https://github.com/ozwaldorf/lutgen-rs" }
+    { "name": "lutgen-rs", "repo": "ozwaldorf/lutgen-rs", "vcs": "https://github.com/ozwaldorf/lutgen-rs", "subdir": "" }
   ]
 }
 ```
+
+The optional `subdir` path is relative to the repository root and tells the
+build scripts where to run vendoring commands. Leave it empty when dependencies
+are fetched from the repository root.
 
 ## Building tarballs
 
 Language specific scripts in `ci/` can be used to create dependency tarballs locally:
 
 ```bash
-jq -n '{"name":"glow","repo":"charmbracelet/glow","vcs":"https://github.com/charmbracelet/glow.git","tag":"v1.4.1"}' \
+jq -n '{"name":"glow","repo":"charmbracelet/glow","vcs":"https://github.com/charmbracelet/glow.git","tag":"v1.4.1","subdir":""}' \
   | bash ci/build-go-deps.sh
 ```
 

--- a/config/vendor_manifest.json
+++ b/config/vendor_manifest.json
@@ -40,7 +40,8 @@
             "name": "BLAKE3",
             "repo": "BLAKE3-team/BLAKE3",
             "vcs": "https://github.com/BLAKE3-team/BLAKE3",
-            "preemptive_count": 1
+            "preemptive_count": 1,
+            "subdir": "b3sum"
         }
     ]
 }


### PR DESCRIPTION
Add optional `subdir` field to vendor manifest configuration allowing
dependencies to be built from subdirectories within repositories
rather than only from the root.

- Update GitHub Actions workflows to pass subdir parameter
- Modify Go and Rust build scripts to change to subdir before vendoring
- Add subdir field to vendor_manifest.json schema with BLAKE3/b3sum example
- Update README documentation explaining subdir usage
- Enhance build-common.lib.sh to parse optional subdir field

This enables vendoring dependencies from monorepos or projects where
the buildable code exists in a subdirectory. This also ensures that things like BLAKE3's `b3sum` can be vendored.
